### PR TITLE
create metadata table as kudu table

### DIFF
--- a/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/impala/createMetaDataTable.sql
+++ b/flyway-core/src/main/resources/org/flywaydb/core/internal/dbsupport/impala/createMetaDataTable.sql
@@ -15,14 +15,14 @@
 --
 
 CREATE TABLE ${schema}.${table} (
-    installed_rank INT ,
+    installed_rank INT PRIMARY KEY,
     version STRING,
     description STRING,
     type STRING,
     script STRING,
     checksum INT,
     installed_by STRING,
-    installed_on TIMESTAMP ,
-    execution_time INT ,
+    installed_on TIMESTAMP,
+    execution_time INT,
     success BOOLEAN
-);
+) STORED AS KUDU;


### PR DESCRIPTION
creating the metadata table as Kudu table using Impala, i.e as an internal table. 
this Kudu table is managed by Impala and is easier to drop rows from impala when a migration fails.